### PR TITLE
userAtom を追加

### DIFF
--- a/src/stores/userAtom.ts
+++ b/src/stores/userAtom.ts
@@ -1,0 +1,42 @@
+import { atom } from 'jotai';
+import { loadable } from 'jotai/utils';
+import { type SigninedUser } from '@/types/user';
+import { waitMs } from '@/utils/promise';
+
+const fetchUser = async (): Promise<SigninedUser<boolean>> => {
+  await waitMs(2000);
+
+  const user: SigninedUser<boolean> = {
+    signined: true,
+    id: '0000-0000-0000-0000',
+    firstName: '智',
+    lastName: '佐藤',
+    firstNameKana: 'さとる',
+    lastNameKana: 'さとう',
+    skills: ['JavaScript', 'TypeScript', 'React'],
+    graduationYear: 2027,
+    slackName: '',
+    iconUrl: 'https://via.placeholder.com/50',
+    type: 'active',
+    grade: 'B1',
+    position: '部員',
+    studentNumber: 'k23075',
+    birthdate: '2005-01-05',
+    email: 'satooru@syscat.net',
+    gender: '男',
+    phoneNumber: '090-0000-0000',
+    currentAddress: {
+      address: '愛知県名古屋市',
+      postalCode: '460-0000',
+    },
+    homeAddress: {
+      address: '愛知県名古屋市',
+      postalCode: '460-0000',
+    },
+  };
+
+  return user;
+};
+
+const userAtom = atom(async () => await fetchUser());
+export const userAtomLoadable = loadable(userAtom);

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -53,3 +53,13 @@ export interface UserBase {
 export type User<WithPrivate extends boolean> = UserBase &
   (ActiveUserProps | OBOGMemberProps | ExternalMember) &
   (WithPrivate extends true ? PrivateProps : Record<never, never>);
+
+type IsSigninedUser = {
+  signined: true;
+} & User<true>;
+
+interface IsNotSigninedUser {
+  signined: false;
+}
+
+export type SigninedUser<T extends boolean> = T extends true ? IsSigninedUser : IsNotSigninedUser;


### PR DESCRIPTION
Closes https://github.com/SystemEngineeringTeam/meibo-system-front/issues/8

## 説明
ユーザー情報を取得するatomを追加

## 現在の動作 (更新前)
なかった

## 新しい動作 (更新後)
ユーザー情報を取得できる

## 追加情報

<!-- その他の情報があれば追加してください -->
